### PR TITLE
fix: z-index QR text

### DIFF
--- a/src/routes/join/scan.svelte
+++ b/src/routes/join/scan.svelte
@@ -46,7 +46,7 @@
 
 <div class="w-full h-screen flex flex-col -mt-20">
 	<div class="h-4/5 bg-black flex items-center overflow-hidden relative">
-		<div class="absolute top-28 text-center w-full text-white"><h1 class="text-2xl">Scan your friend's QR code</h1></div>
+		<div class="absolute top-28 text-center w-full z-10 text-white"><h1 class="text-2xl">Scan your friend's QR code</h1></div>
 		<div id="reader" class="w-full max-h-full" />
 	</div>
 	<div class="flex p-6 h-1/5">


### PR DESCRIPTION
Fixing text `Scan your friend’s QR code` to the top of camera area's div with `z-10`

This PR closes #17 